### PR TITLE
Added Calls to MDPClient private Ctors

### DIFF
--- a/src/Majordomo/MajordomoProtocol/MDPClient.cs
+++ b/src/Majordomo/MajordomoProtocol/MDPClient.cs
@@ -69,7 +69,7 @@ namespace MajordomoProtocol
         /// <param name="brokerAddress">address the broker can be connected to</param>
         /// <param name="identity">if present will become the name for the client socket, encoded in UTF8</param>
         public MDPClient (string brokerAddress, byte[] identity = null)
-            : this ()
+            : this()
         {
             if (string.IsNullOrWhiteSpace (brokerAddress))
                 throw new ArgumentNullException (nameof(brokerAddress), "The broker address must not be null, empty or whitespace!");
@@ -83,7 +83,8 @@ namespace MajordomoProtocol
         /// </summary>
         /// <param name="brokerAddress">address the broker can be connected to</param>
         /// <param name="identity">sets the name of the client (must be UTF8), if empty or white space it is ignored</param>
-        public MDPClient (string brokerAddress, string identity)
+        public MDPClient (string brokerAddress, string identity) 
+				: this()
         {
             if (string.IsNullOrWhiteSpace (brokerAddress))
                 throw new ArgumentNullException (nameof(brokerAddress), "The broker address must not be null, empty or whitespace!");

--- a/src/Majordomo/MajordomoProtocol/MDPClientAsync.cs
+++ b/src/Majordomo/MajordomoProtocol/MDPClientAsync.cs
@@ -96,6 +96,7 @@ namespace MajordomoProtocol
         /// <param name="brokerAddress">address the broker can be connected to</param>
         /// <param name="identity">sets the name of the client (must be UTF8), if empty or white space it is ignored</param>
         public MDPClientAsync([NotNull] string brokerAddress, string identity)
+				: this()
         {
             if (string.IsNullOrWhiteSpace(brokerAddress))
                 throw new ArgumentNullException(nameof(brokerAddress), "The broker address must not be null, empty or whitespace!");


### PR DESCRIPTION
I have added missing private ctors calls to the overloaded ctors for `MDPClient` and `MDPClientAsync`. Note, the spacing is not ideal as my production machine uses different spacing settings. 