### PR TITLE
fix some bugs of Paranoid Pirate

### DIFF
--- a/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Program.cs
+++ b/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Program.cs
@@ -133,6 +133,7 @@ namespace ParanoidPirate.Queue
 
                 poller.Add(frontend);
                 poller.Add(backend);
+                poller.Add(timer);
 
                 poller.RunAsync();
 

--- a/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Workers.cs
+++ b/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Workers.cs
@@ -45,8 +45,9 @@ namespace ParanoidPirate.Queue
         /// </summary>
         public void Purge()
         {
-            foreach (var worker in m_workers.Where(worker => worker.Expiry >= DateTime.UtcNow))
+            foreach (var worker in m_workers.Where(worker => worker.Expiry < DateTime.UtcNow).ToList())
                 m_workers.Remove(worker);
+                
         }
 
         public IEnumerator<Worker> GetEnumerator()

--- a/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Worker/Program.cs
+++ b/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Worker/Program.cs
@@ -29,7 +29,7 @@ namespace ParanoidPirate.Worker
             // if liveliness == 0 -> queue is considered dead/disconnected
             var liveliness = Commons.HeartbeatLiveliness;
             var interval = Commons.IntervalInit;
-            var heartbeatAt = DateTime.UtcNow + + TimeSpan.FromMilliseconds(Commons.HeartbeatInterval);
+            var heartbeatAt = DateTime.UtcNow + TimeSpan.FromMilliseconds(Commons.HeartbeatInterval);
             var cycles = 0;
             var crash = false;
 
@@ -118,7 +118,7 @@ namespace ParanoidPirate.Worker
                 // if it is time the worker will send a heartbeat so QUEUE can detect a dead worker
                 if (DateTime.UtcNow > heartbeatAt)
                 {
-                    heartbeatAt = DateTime.UtcNow + + TimeSpan.FromMilliseconds(Commons.HeartbeatInterval);
+                    heartbeatAt = DateTime.UtcNow + TimeSpan.FromMilliseconds(Commons.HeartbeatInterval);
 
                     Console.WriteLine("[WORKER] sending heartbeat!");
 

--- a/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Worker/Program.cs
+++ b/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Worker/Program.cs
@@ -29,7 +29,7 @@ namespace ParanoidPirate.Worker
             // if liveliness == 0 -> queue is considered dead/disconnected
             var liveliness = Commons.HeartbeatLiveliness;
             var interval = Commons.IntervalInit;
-            var heartbeatAt = DateTime.UtcNow.Millisecond + Commons.HeartbeatInterval;
+            var heartbeatAt = DateTime.UtcNow + + TimeSpan.FromMilliseconds(Commons.HeartbeatInterval);
             var cycles = 0;
             var crash = false;
 
@@ -116,9 +116,9 @@ namespace ParanoidPirate.Worker
                     }
                 }
                 // if it is time the worker will send a heartbeat so QUEUE can detect a dead worker
-                if (DateTime.UtcNow.Millisecond > heartbeatAt)
+                if (DateTime.UtcNow > heartbeatAt)
                 {
-                    heartbeatAt = DateTime.UtcNow.Millisecond + Commons.HeartbeatInterval;
+                    heartbeatAt = DateTime.UtcNow + + TimeSpan.FromMilliseconds(Commons.HeartbeatInterval);
 
                     Console.WriteLine("[WORKER] sending heartbeat!");
 


### PR DESCRIPTION
1、Add timer to poller；
2、Fix the bug of  the purge method;
3、Fix the problem of expiry calculation of worker.