### PR TITLE
Fixed load balancing of workers

### DIFF
--- a/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Workers.cs
+++ b/src/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Workers.cs
@@ -33,9 +33,9 @@ namespace ParanoidPirate.Queue
                 return null;
 
             // get the oldest worker
-            var worker = m_workers.Last();
+            var worker = m_workers[0];
             // remove it from list
-            m_workers.Remove(worker);
+            m_workers.RemoveAt(0);
 
             return worker.Identity;
         }


### PR DESCRIPTION
The implementation adds free workers to the end of the list the oldest worker should be taken from the start of the list.